### PR TITLE
Removendo public de métodos de interface que já é implicitamente public

### DIFF
--- a/src/main/java/br/com/fiap/lanchonete/dominio/portas/interfaces/CategoriaServicePort.java
+++ b/src/main/java/br/com/fiap/lanchonete/dominio/portas/interfaces/CategoriaServicePort.java
@@ -8,14 +8,14 @@ import java.util.Optional;
 
 public interface CategoriaServicePort {
 
-	public List<CategoriaResponseDto> buscarTodos();
+	List<CategoriaResponseDto> buscarTodos();
 
-	public Optional<CategoriaResponseDto> buscarPorId(Long id);
+	Optional<CategoriaResponseDto> buscarPorId(Long id);
 
-	public CategoriaResponseDto adicionar(CategoriaRequestDto categoriaRequestDto);
+	CategoriaResponseDto adicionar(CategoriaRequestDto categoriaRequestDto);
 
-	public CategoriaResponseDto alterar(Long id, CategoriaRequestDto categoriaRequestDto);
+	CategoriaResponseDto alterar(Long id, CategoriaRequestDto categoriaRequestDto);
 
-	public void excluir(Long id);
+	void excluir(Long id);
 
 }

--- a/src/main/java/br/com/fiap/lanchonete/dominio/portas/interfaces/ClienteServicePort.java
+++ b/src/main/java/br/com/fiap/lanchonete/dominio/portas/interfaces/ClienteServicePort.java
@@ -6,14 +6,14 @@ import br.com.fiap.lanchonete.dominio.dtos.ClientesDto;
 
 public interface ClienteServicePort {
 
-	public List<ClientesDto> buscarTodos();
+	List<ClientesDto> buscarTodos();
 
-	public ClientesDto incluir(ClientesDto clientesDto);
+	ClientesDto incluir(ClientesDto clientesDto);
 
-	public ClientesDto alterar(ClientesDto clientesDto);
+	ClientesDto alterar(ClientesDto clientesDto);
 
-	public void excluir(Long id);
+	void excluir(Long id);
 
-	public ClientesDto BuscarPorCPF(String cpf);
+	ClientesDto BuscarPorCPF(String cpf);
 
 }

--- a/src/main/java/br/com/fiap/lanchonete/dominio/portas/interfaces/PedidoServicePort.java
+++ b/src/main/java/br/com/fiap/lanchonete/dominio/portas/interfaces/PedidoServicePort.java
@@ -6,6 +6,6 @@ import br.com.fiap.lanchonete.dominio.dtos.PedidoDto;
 
 public interface PedidoServicePort {
 
-	public List<PedidoDto> buscarTodos();
+	List<PedidoDto> buscarTodos();
 
 }

--- a/src/main/java/br/com/fiap/lanchonete/dominio/portas/interfaces/ProdutoServicePort.java
+++ b/src/main/java/br/com/fiap/lanchonete/dominio/portas/interfaces/ProdutoServicePort.java
@@ -6,14 +6,14 @@ import br.com.fiap.lanchonete.dominio.dtos.ProdutosDto;
 
 public interface ProdutoServicePort {
 
-	public List<ProdutosDto> findAll();
+	List<ProdutosDto> findAll();
 
-	public ProdutosDto incluir(ProdutosDto produtosDto);
+	ProdutosDto incluir(ProdutosDto produtosDto);
 
-	public ProdutosDto alterar(ProdutosDto produtosDtoRequest);
+	ProdutosDto alterar(ProdutosDto produtosDtoRequest);
 
-	public void excluir(Long id);
+	void excluir(Long id);
 
-	public List<ProdutosDto> buscarPorCategoria(String categoria);
+	List<ProdutosDto> buscarPorCategoria(String categoria);
 
 }

--- a/src/main/java/br/com/fiap/lanchonete/dominio/portas/repositories/CategoriaRepositoryPort.java
+++ b/src/main/java/br/com/fiap/lanchonete/dominio/portas/repositories/CategoriaRepositoryPort.java
@@ -7,14 +7,14 @@ import br.com.fiap.lanchonete.dominio.Categoria;
 
 public interface CategoriaRepositoryPort {
 
-	public List<Categoria> buscarTodos();
+	List<Categoria> buscarTodos();
 
-	public Optional<Categoria> buscarPorId(Long id);
+	Optional<Categoria> buscarPorId(Long id);
 
-	public Categoria adicionar(Categoria categoria);
+	Categoria adicionar(Categoria categoria);
 
-	public Categoria alterar(Categoria categoria);
+	Categoria alterar(Categoria categoria);
 
-	public void excluir(Long id);
+	void excluir(Long id);
 
 }

--- a/src/main/java/br/com/fiap/lanchonete/dominio/portas/repositories/ClienteRepositoryPort.java
+++ b/src/main/java/br/com/fiap/lanchonete/dominio/portas/repositories/ClienteRepositoryPort.java
@@ -6,14 +6,14 @@ import br.com.fiap.lanchonete.dominio.Cliente;
 
 public interface ClienteRepositoryPort {
 
-	public List<Cliente> buscarTodos();
+	List<Cliente> buscarTodos();
 
-	public Cliente incluir(Cliente cliente);
+	Cliente incluir(Cliente cliente);
 
-	public Cliente alterar(Cliente cliente);
+	Cliente alterar(Cliente cliente);
 
-	public void excluir(Long id);
+	void excluir(Long id);
 
-	public Cliente buscarPorCPF(String cpf);
+	Cliente buscarPorCPF(String cpf);
 
 }

--- a/src/main/java/br/com/fiap/lanchonete/dominio/portas/repositories/PedidoRepositoryPort.java
+++ b/src/main/java/br/com/fiap/lanchonete/dominio/portas/repositories/PedidoRepositoryPort.java
@@ -6,6 +6,6 @@ import br.com.fiap.lanchonete.dominio.Pedido;
 
 public interface PedidoRepositoryPort {
 
-	public List<Pedido> buscarTodos();
+	List<Pedido> buscarTodos();
 
 }

--- a/src/main/java/br/com/fiap/lanchonete/dominio/portas/repositories/ProdutoRepositoryPort.java
+++ b/src/main/java/br/com/fiap/lanchonete/dominio/portas/repositories/ProdutoRepositoryPort.java
@@ -6,14 +6,14 @@ import br.com.fiap.lanchonete.dominio.Produto;
 
 public interface ProdutoRepositoryPort {
 
-	public List<Produto> findAll();
+	List<Produto> findAll();
 
-	public Produto incluir(Produto produto);
+	Produto incluir(Produto produto);
 
-	public Produto alterar(Produto produto);
+	Produto alterar(Produto produto);
 
-	public void excluir(Long id);
+	void excluir(Long id);
 
-	public List<Produto> buscarPorCategoria(String categoria);
+	List<Produto> buscarPorCategoria(String categoria);
 
 }

--- a/src/main/java/br/com/fiap/lanchonete/infraestrutura/adaptadores/repositories/SpringCategoriasRepository.java
+++ b/src/main/java/br/com/fiap/lanchonete/infraestrutura/adaptadores/repositories/SpringCategoriasRepository.java
@@ -8,6 +8,6 @@ import br.com.fiap.lanchonete.infraestrutura.adaptadores.entidades.CategoriaEnti
 @Repository
 public interface SpringCategoriasRepository extends JpaRepository<CategoriaEntity, Long> {
 
-	public CategoriaEntity findByNome(String string);
+	CategoriaEntity findByNome(String string);
 
 }

--- a/src/main/java/br/com/fiap/lanchonete/infraestrutura/adaptadores/repositories/SpringClientesRepository.java
+++ b/src/main/java/br/com/fiap/lanchonete/infraestrutura/adaptadores/repositories/SpringClientesRepository.java
@@ -8,5 +8,5 @@ import br.com.fiap.lanchonete.infraestrutura.adaptadores.entidades.ClienteEntity
 @Repository
 public interface SpringClientesRepository extends JpaRepository<ClienteEntity, Long> {
 
-	public ClienteEntity findByCPF(String cpf);
+	ClienteEntity findByCPF(String cpf);
 }

--- a/src/main/java/br/com/fiap/lanchonete/infraestrutura/adaptadores/repositories/SpringLogradouroRepository.java
+++ b/src/main/java/br/com/fiap/lanchonete/infraestrutura/adaptadores/repositories/SpringLogradouroRepository.java
@@ -8,6 +8,6 @@ import br.com.fiap.lanchonete.infraestrutura.adaptadores.entidades.LogradouroEnt
 @Repository
 public interface SpringLogradouroRepository extends JpaRepository<LogradouroEntity, Long> {
 
-	public LogradouroEntity findByNome(String string);
+	LogradouroEntity findByNome(String string);
 
 }

--- a/src/main/java/br/com/fiap/lanchonete/infraestrutura/adaptadores/repositories/SpringProdutoRepository.java
+++ b/src/main/java/br/com/fiap/lanchonete/infraestrutura/adaptadores/repositories/SpringProdutoRepository.java
@@ -10,8 +10,8 @@ import br.com.fiap.lanchonete.infraestrutura.adaptadores.entidades.ProdutoEntity
 @Repository
 public interface SpringProdutoRepository extends JpaRepository<ProdutoEntity, Long> {
 
-	public List<ProdutoEntity> findByCategoriasNome(String categoria);
+	List<ProdutoEntity> findByCategoriasNome(String categoria);
 
-	public List<ProdutoEntity> findByNome(String nome);
+	List<ProdutoEntity> findByNome(String nome);
 
 }


### PR DESCRIPTION
Bem cada declaração de método no corpo de uma interface é implicitamente `public` então não precisamos indicar, e ai resolve criar esse PR pra isso. 

Mais detalhes: https://docs.oracle.com/javase/specs/jls/se7/html/jls-9.html#jls-9.4