### PR TITLE
fix: correcao do healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       POSTGRES_DB: ${DB_NAME}
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - 5432:5432
     volumes:
       - ./tmp/database:/var/lib/postgresql/data
     healthcheck: #verificação da saúde do container
@@ -50,7 +52,7 @@ services:
       database:
         condition: service_healthy #inicia o container do app só quando o postgres disser que está healthy
     healthcheck:
-      test: "curl --fail --silent localhost:8081/actuator/health | grep UP || exit 1"
+      test: wget --no-verbose --tries=1 --spider localhost:8081/actuator/health || exit 1
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Quando fui testar fazer `docker compose up`, não consegui acessar o banco por causa da porta, e o app dava `unhealthy`, como ta com `alpine linux`, não tem o `curl`, ai troquei pra `wget`